### PR TITLE
PhotosApi: $photoset should be an array

### DIFF
--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -474,7 +474,7 @@ class PhotosApi extends ApiMethodGroup
             }
             foreach ($sets['photoset'] as $photoset) {
                 foreach ($photoIds as $photoId) {
-                    if (in_array($photoId, $photoset['has_requested_photos'])) {
+                    if (is_array($photoset['has_requested_photos']) && in_array($photoId, $photoset['has_requested_photos'])) {
                         $out[] = $photoset;
                     }
                 }


### PR DESCRIPTION
Hello,
Here a fix when using the librairy to import photo through Flickr2Piwigo. I got the following error when importing photos from my account:

```
<br />
<b>Fatal error</b>:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /config/www/plugins/flickr2piwigo/vendor/samwilson/phpflickr/src/PhotosApi.php:477
Stack trace:
#0 /config/www/plugins/flickr2piwigo/vendor/samwilson/phpflickr/src/PhotosApi.php(477): in_array()
#1 /config/www/plugins/flickr2piwigo/include/ws_functions.inc.php(147): Samwilson\PhpFlickr\PhotosApi-&gt;getSets()
#2 /app/www/public/include/ws_core.inc.php(600): ws_flickr2piwigo_importPhoto()
#3 /app/www/public/include/ws_protocols/rest_handler.php(41): PwgServer-&gt;invoke()
#4 /app/www/public/include/ws_core.inc.php(281): PwgRestRequestHandler-&gt;handleRequest()
#5 /app/www/public/ws.php(22): PwgServer-&gt;run()
#6 {main}
  thrown in <b>/config/www/plugins/flickr2piwigo/vendor/samwilson/phpflickr/src/PhotosApi.php</b> on line <b>477</b><br />
```